### PR TITLE
加入viewportWidth和rootValue的函数写法支持，方便在编译过程中通过函数动态设置,并在参数中返回源文件路径

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,12 +15,12 @@ module.exports = (options = {}) => {
       if (decl.value.indexOf('px') === -1) return;
       const value = decl.value;
       if (opts.viewportWidth) {
-        const viewportWidth = typeof opts.viewportWidth === 'function' ? opts.viewportWidth(opts, decl) : opts.viewportWidth
+        const viewportWidth = typeof opts.viewportWidth === 'function' ? opts.viewportWidth(opts, decl, decl.source.input.file) : opts.viewportWidth
         const pxReplaceForVw = createPxReplace(viewportWidth / 100, opts.minPixelValue, opts.unitPrecision, 'vw');
         decl.value = value.replace(pxRegex, pxReplaceForVw);
       }
       if (opts.rootValue) {
-        const rootValue = typeof opts.rootValue === 'function' ? opts.rootValue(opts, decl) : opts.rootValue
+        const rootValue = typeof opts.rootValue === 'function' ? opts.rootValue(opts, decl, decl.source.input.file) : opts.rootValue
         const pxReplaceForRem = createPxReplace(rootValue, opts.minPixelValue, opts.unitPrecision, 'rem');
         if (opts.viewportWidth) {
           var newValue = value.replace(pxRegex, pxReplaceForRem);

--- a/index.js
+++ b/index.js
@@ -15,11 +15,13 @@ module.exports = (options = {}) => {
       if (decl.value.indexOf('px') === -1) return;
       const value = decl.value;
       if (opts.viewportWidth) {
-        const pxReplaceForVw = createPxReplace(opts.viewportWidth / 100, opts.minPixelValue, opts.unitPrecision, 'vw');
+        const viewportWidth = typeof opts.viewportWidth === 'function' ? opts.viewportWidth(opts, decl) : opts.viewportWidth
+        const pxReplaceForVw = createPxReplace(viewportWidth / 100, opts.minPixelValue, opts.unitPrecision, 'vw');
         decl.value = value.replace(pxRegex, pxReplaceForVw);
       }
       if (opts.rootValue) {
-        const pxReplaceForRem = createPxReplace(opts.rootValue, opts.minPixelValue, opts.unitPrecision, 'rem');
+        const rootValue = typeof opts.rootValue === 'function' ? opts.rootValue(opts, decl) : opts.rootValue
+        const pxReplaceForRem = createPxReplace(rootValue, opts.minPixelValue, opts.unitPrecision, 'rem');
         if (opts.viewportWidth) {
           var newValue = value.replace(pxRegex, pxReplaceForRem);
           if (newValue !== value) {


### PR DESCRIPTION
注：
    已经过测试，不影响插件原来使用方式
修改内容：
    合并此提交后使用者可以动态设置viewportWidth和rootValue，例如我在项目中遇到项目即需要适配手机端又需要适配平板，然而两端的少部分页面业务逻辑差异较大，不过大部分内容可以通用，所以想放在一个项目框架中，编译生成一个项目；此修改的目的就是在viewportWidth或rootValue的函数方式中根据不同的文件夹路径区分给到不同的尺寸或根元素大小；